### PR TITLE
Validate that case_ids exist in TR run before sending

### DIFF
--- a/src/Reporter.js
+++ b/src/Reporter.js
@@ -44,6 +44,7 @@ class Reporter {
         this.includeAllCasesDuringCreation = configService.includeAllCasesDuringCreation();
         this.includeAllFailedScreenshots = configService.includeAllFailedScreenshots();
         this.ignorePendingTests = configService.ignorePendingCypressTests();
+        this.ignoreMissingCaseIDs = configService.ignoreMissingCaseIds();
 
         this.modeCreateRun = !configService.hasRunID();
         this.closeRun = configService.shouldCloseRun();
@@ -256,7 +257,11 @@ class Reporter {
 
         if (allResults.length > 0) {
             for (let i = 0; i < this.runIds.length; i += 1) {
-                const request = this.testrail.sendBatchResults(this.runIds[i], allResults);
+                const request = this.testrail.sendBatchResults(
+                    this.runIds[i], 
+                    allResults, 
+                    this.ignoreMissingCaseIDs,
+                    );
                 allRequests.push(request);
             }
 

--- a/src/components/TestRail/ApiClient.js
+++ b/src/components/TestRail/ApiClient.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const ApiError = require('./ApiError');
 const FormData = require('form-data');
 const fs = require('fs');
+// const ColorConsole = require('../../services/ColorConsole');
 
 class ApiClient {
     /**
@@ -14,6 +15,35 @@ class ApiClient {
         this.password = password;
         this.baseUrl = `https://${domain}/index.php?/api/v2`;
     }
+
+/**
+ *
+ * @param slug
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+getData(slug, params={}) {
+    const fullUrl = this.baseUrl + slug;
+    return axios({
+        method: 'get',
+        url: fullUrl,
+        auth: {
+            username: this.username,
+            password: this.password,
+        },
+        params,
+    })
+        .then((response) => {
+            // ColorConsole.debug('>> getData response: ' + JSON.stringify(response.data));
+            return response;
+        })
+        .catch((error) => {
+            // Extract and handle the error
+            const apiError = new ApiError(error);
+            throw new Error(
+                `Error fetching data: ${apiError.getStatusCode()} ${apiError.getStatusText()} >> ${apiError.getErrorText()}`
+            );
+        });
+}
 
     /**
      *

--- a/src/components/TestRail/TestRail.js
+++ b/src/components/TestRail/TestRail.js
@@ -29,7 +29,15 @@ class TestRail {
      * @param callback
      * @returns {Promise<AxiosResponse<*>>}
      */
-    createRun(projectId, milestoneId, suiteId, name, description, includeAllCasesDuringCreation, callback) {
+    createRun(
+        projectId,
+        milestoneId,
+        suiteId,
+        name,
+        description,
+        includeAllCasesDuringCreation,
+        callback,
+        ) {
         if (typeof includeAllCasesDuringCreation !== 'boolean') {
             includeAllCasesDuringCreation = false; //preserving existing functionality
         }
@@ -174,15 +182,52 @@ class TestRail {
      *
      * @param {string} runID
      * @param {Result[]} testResults
+     * @param {boolean} ignoreMissingCaseIds
      * @returns {Promise<AxiosResponse<*>>}
      */
-    sendBatchResults(runID, testResults) {
+    async sendBatchResults(runID, testResults, ignoreMissingCaseIds) {
+        if (typeof ignoreMissingCaseIds !== 'boolean') {
+            ignoreMissingCaseIds = false; //preserving existing functionality
+        }
+        
+        // Check if there are any test results to send
+        ColorConsole.info('\n  Cypress-TestRail send batch results:');
+        let validCaseIds = [];
+        
+        if (ignoreMissingCaseIds) { // validCaseIds is only needed if Validating case_id
+            // Fetch valid case IDs for the given runID
+            let testsCaseIdPage = [];
+            // Pagination variables
+            let offset = 0;
+            const limit = 250; // Maximum allowed by TestRail
+
+            // Fetch valid case IDs from TestRail API
+            try { 
+                // eslint-disable-next-line no-constant-condition
+                while (true) {             
+                    const getDataResponse = await this.client.getData(
+                        `/get_tests/${runID}`,
+                        {offset, limit},
+                    );
+                    // Extract valid case IDs from the response data
+                    testsCaseIdPage = getDataResponse.data.tests.map((test) => test.case_id);
+                
+                    if (testsCaseIdPage.length === 0) break;  // we've retrieved all case IDs                    
+                    validCaseIds = validCaseIds.concat(testsCaseIdPage);
+                    offset += limit; // Move to the next page
+                }
+            } catch (error) {
+                ColorConsole.error(`Could not fetch valid case IDs for run R${runID}: ${error.message}`);
+                return; // Exit the function if fetching valid case IDs fails
+            }
+            // ColorConsole.debug('>> testResults validCaseIds: ' + JSON.stringify(validCaseIds));
+            ColorConsole.info(` In run R${runID} there are ${validCaseIds.length} Valid Testrail cases\n`);
+        }
+
         const url = '/add_results_for_cases/' + runID;
-
-        const postData = {
-            results: [],
-        };
-
+        const postData = { results: [] }; 
+    
+        // Filter testResults to include only those with valid case IDs
         testResults.forEach((result) => {
             var resultEntry = {
                 case_id: result.getCaseId(),
@@ -190,18 +235,24 @@ class TestRail {
                 comment: result.getComment().trim(),
                 screenshotPaths: result.getScreenshotPaths(),
             };
-
             // only add an elapsed time, if a valid value exists
             // otherwise TestRail will throw an error
             if (result.hasElapsedTime()) {
                 resultEntry.elapsed = result.getElapsed();
             }
-            
-            postData.results.push(resultEntry);
+    
+            // Check if the case_id is valid ie in the run
+            if (ignoreMissingCaseIds && 
+                !validCaseIds.includes(parseInt(resultEntry.case_id))) { // Check if the case_id is valid
+                    ColorConsole.error(`Test case C${resultEntry.case_id} is not valid for run R${runID}. Skipping.`);
+            } else {
+                postData.results.push(resultEntry);            
+            }
         });
-        // ColorConsole.debug('');
+
         // ColorConsole.debug('>> BEFORE postData.results: ' + JSON.stringify(postData));
-        postData.results = this.resultsAggregator.aggregateDuplicateResults(postData.results); // cypress-testrail-greenwich mod
+        // Aggregates multiple tests, all match, pass for the test rails to be marked as a pass
+        postData.results = this.resultsAggregator.aggregateDuplicateResults(postData.results);
         // ColorConsole.debug('>> AFTER postData.results: ' + JSON.stringify(postData)); 
 
         return this.client.sendData(
@@ -209,7 +260,6 @@ class TestRail {
             postData,
             (response) => {
                 
-                ColorConsole.success('Cypress-TestRail:');
                 ColorConsole.success('Cypress results sent to TestRail R' 
                     + runID + ' for: ' + postData.results.map((r) => 'C' + r.case_id).join(', '));
 

--- a/src/services/Config/ConfigService.js
+++ b/src/services/Config/ConfigService.js
@@ -177,6 +177,14 @@ class ConfigService {
         return this._valueLoader.getBooleanValue('TESTRAIL_RUN_INCLUDE_ALL', 'runIncludeAll', false);
     }
 
+  /**
+     *
+     * @returns {boolean}
+     */
+  ignoreMissingCaseIds() {
+        return this._valueLoader.getBooleanValue('TESTRAIL_IGNORE_MISSING_CASE_IDS', 'ignoreMissingCaseIds', false);
+    }
+
     /**
      *
      * @returns {boolean}


### PR DESCRIPTION
Cypress tests labeled with Testrail case IDs may cover all cases that appear in Testrail master project. This does not mean that any particular  Testrail run contains all such cases. The modifications here first check and validate that the case IDs exist in the particular targeted Testrail run, before attempting to transmit them. If a case ID is not in the target Testrail run then it is skipped and noted as such in the console output.

Example of new console outfit 
```
>> In run R26444 there are 395 Valid Testrail cases 
 Test case C62600 is not valid for run R26444. Skipping. 
 Test case C62597 is not valid for run R26444. Skipping. 
 Cypress-TestRail: 
 Cypress results sent to TestRail R26444 for: C40039, C40040, C40041, C40043 
```
 - fixes #6 